### PR TITLE
fix: pagination was off when searching

### DIFF
--- a/src/app/emotes/emote-list/emote-list.component.html
+++ b/src/app/emotes/emote-list/emote-list.component.html
@@ -28,18 +28,18 @@
 					<div class="d-flex flex-wrap justify-content-center">
 						<div (click)="selectEmote(emoteEl, emote)"  #emoteEl *ngFor="let emote of emotes | async" class="is-emote-card">
 							<app-emote-card [emote]="emote" [contextMenu]="contextMenu.emoteMenu" (openContext)="onOpenCardContextMenu($event)">
-				
+
 							</app-emote-card>
 						</div>
 					</div>
 				</div>
 			</div>
-		
+
 			<!-- Pagination menu -->
 			<mat-paginator #paginator (page)="onPageEvent($event)" [@fadeout]="selecting | async"
-				[showFirstLastButtons]="true" [pageIndex]="pageOptions?.page" [length]="pageOptions?.length"
+				[showFirstLastButtons]="true" [pageIndex]="pageOptions?.page"
 				[length]="totalEmotes | async" [pageSize]="pageSize | async">
-		
+
 			</mat-paginator>
 		</div>
 	</div>

--- a/src/app/emotes/emote-list/emote-list.component.ts
+++ b/src/app/emotes/emote-list/emote-list.component.ts
@@ -133,7 +133,15 @@ export class EmoteListComponent implements OnInit, AfterViewInit, OnDestroy {
 		const size = this.calculateSizedRows();
 		return this.restService.v2.SearchEmotes((this.pageOptions?.page ?? (page - 1)) + 1, size ?? 16, options ?? this.currentSearchOptions).pipe(
 			takeUntil(this.newPage.pipe(take(1))),
-			tap(res => this.totalEmotes.next(res?.total_estimated_size ?? 0)),
+			tap(res => {
+				this.totalEmotes.next(res?.total_estimated_size ?? 0);
+				this.skipNextSearchCheck = true;
+				this.paginator?.page.next({
+					length: res?.total_estimated_size ?? 0,
+					pageIndex: this.paginator?.pageIndex ?? 0,
+					pageSize: this.paginator?.pageSize ?? 0,
+			   });
+			}),
 			delay(200),
 			map(res => res?.emotes ?? []),
 			mergeAll(),


### PR DESCRIPTION
`EmoteListComponent#onPageEvent` wasn't called when the length (`totalEmotes`) was updated - basically when searching. This caused the title and the `localStorage` entry to be wrong (it saved the previous length). This PR fixes this.