### PR TITLE
Fix Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,13 +3,19 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = tabs
+indent_style = tab
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.ts]
+# NOTE: `quote_type` isn't part of the standard 
+# (https://editorconfig-specification.readthedocs.io/#supported-pairs)
+# noinspection EditorConfigKeyCorrectness
 quote_type = single
+# workaround for IntelliJ based IDEs 
+# (see https://youtrack.jetbrains.com/issue/WEB-21157#focus=Comments-27-3617910.0-0)
+ij_typescript_use_double_quotes = false
 
 [*.md]
 max_line_length = off


### PR DESCRIPTION
* Change `ident_style` to `tab` (`tabs` is not standard)
* Add `ij_typescript_use_double_quotes` as a workaround for `quote_type` and suppress inpection in IntelliJ


It's probably good to add [prettier](https://prettier.io) to the project as it's IDE independent and has more options (but keep the editorconfig).