### PR TITLE
Fix "Editor Of" showing a broken list

### DIFF
--- a/src/app/util/user.structure.ts
+++ b/src/app/util/user.structure.ts
@@ -171,7 +171,8 @@ export class UserStructure extends Structure<'user'> {
 		return this.dataOnce().pipe(
 			map(data => data?.editor_in ?? []),
 			mergeAll(),
-			map(u => this.dataService.get('user', u)[0]),
+			map(u => this.dataService.add('user', u)),
+			mergeAll(),
 			toArray()
 		);
 	}


### PR DESCRIPTION
Resolving an issue which caused the "editor of" list on user pages to display users that shouldn't be there, or fail to display users that should be there.