### PR TITLE
Paginate Emote Channels

### DIFF
--- a/src/app/emotes/emote/emote.component.html
+++ b/src/app/emotes/emote/emote.component.html
@@ -117,6 +117,18 @@
 				<span>Nothing here</span>
 				<mat-icon [svgIcon]="(themingService.getSvgIcon('zulul') | async) || ''"></mat-icon>
 			</div>
+
+			<div class="paginator">
+				<button mat-flat-button (click)="queryChannels(channelPage - 1)" [class.invisible]="channelPage <= 1">
+					<mat-icon>arrow_backward</mat-icon>
+				</button>
+
+				<span> Page {{channelPage}}/{{getTotalChannelPages() | async}} </span>
+
+				<button mat-flat-button (click)="queryChannels(channelPage + 1)" [class.invisible]="channelPage >= ((getTotalChannelPages() | async) || 0)">
+					<mat-icon>arrow_forward</mat-icon>
+				</button>
+			</div>
 		</div>
 	</div>
 

--- a/src/app/emotes/emote/emote.component.html
+++ b/src/app/emotes/emote/emote.component.html
@@ -105,8 +105,8 @@
 
 	<!-- Channels Section -->
 	<div class="section-container" [appColor]="themingService.bg.darken(.075)" [isBackground]="true">
-		<span class="section-title">Channels ({{ (channels | async)?.length || 0 }})</span>
-		<div class="section-content" [ngSwitch]="((channels | async)?.length || 0) > 0">
+		<span class="section-title">Channels ({{ (emote?.getChannelCount() | async) || 0 }})</span>
+		<div class="section-content" [ngSwitch]="((emote?.getChannelCount() | async) || 0) > 0">
 			<div class="channel-card-list" *ngSwitchCase="true">
 				<app-emote-channel-card [user]="user" *ngFor="let user of channels | async">
 

--- a/src/app/emotes/emote/emote.component.scss
+++ b/src/app/emotes/emote/emote.component.scss
@@ -47,13 +47,22 @@
 	.section-content {
 		margin-top: .64em;
 		margin-left: .64em;
-	}
-}
 
-.channel-card-list {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
+		.channel-card-list {
+			display: flex;
+			justify-content: center;
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
+
+		.paginator {
+			display: flex;
+			padding-right: 3.5em;
+			padding-left: 3.5em;
+			align-items: center;
+			justify-content: space-between;
+		}
+	}
 }
 
 .visibility-tag {

--- a/src/app/service/rest/gql-fragments.structure.ts
+++ b/src/app/service/rest/gql-fragments.structure.ts
@@ -7,6 +7,7 @@ export namespace GQLFragments {
 			created_at,
 			name,
 			width, height,
+			channel_count,
 			channels {
 				id, login, display_name, role {
 					id, name, color, allowed, denied, position

--- a/src/app/util/emote.structure.ts
+++ b/src/app/util/emote.structure.ts
@@ -86,6 +86,12 @@ export class EmoteStructure extends Structure<'emote'> {
 		);
 	}
 
+	getChannelCount(): Observable<number> {
+		return this.dataOnce().pipe(
+			map(d => d?.channel_count ?? 0)
+		);
+	}
+
 	getURL(size = 3): Observable<string | undefined> {
 		const rest = this.getRestService();
 


### PR DESCRIPTION
Following the deploy of emote channels pagination on the GQL API, move to the new `channel_count` field to display total channels and adding page buttons to navigate around them