### PR TITLE
Emote List - Fix pagination lockup after search

### DIFF
--- a/src/app/emotes/emote-list/emote-list.component.html
+++ b/src/app/emotes/emote-list/emote-list.component.html
@@ -37,8 +37,8 @@
 		
 			<!-- Pagination menu -->
 			<mat-paginator #paginator (page)="onPageEvent($event)" [@fadeout]="selecting | async"
-				[showFirstLastButtons]="true" [pageIndex]="pageOptions?.page" [length]="pageOptions?.length"
-				[length]="totalEmotes | async" [pageSize]="pageSize | async">
+				[showFirstLastButtons]="true" [pageIndex]="pageOptions?.page"
+				[length]="pageOptions?.length || (totalEmotes | async)" [pageSize]="pageSize | async">
 		
 			</mat-paginator>
 		</div>


### PR DESCRIPTION
Fixing an issue which caused the initial pagination click to not go through if the user used search beforehand