### PR TITLE
Show "mark all read" button only after loaded notifications

### DIFF
--- a/src/app/notifications/notify-menu.component.html
+++ b/src/app/notifications/notify-menu.component.html
@@ -9,7 +9,7 @@
 			</div>
 		</div>
 		<div class="quick-actions">
-			<a class="quick-action mark-all-read" (click)="markAllRead()" *ngIf="!clientService.isImpersonating && !allClear">
+			<a class="quick-action mark-all-read" (click)="markAllRead()" *ngIf="!clientService.isImpersonating && !allClear && loaded">
 				Mark All Read
 			</a>
 		</div>


### PR DESCRIPTION
Instead of the "mark all read" notifications button showing and then disappearing when notifications finished loading and there weren't any unreads, only show the button once loading has finished. Clicking the button before loading has finished also errors, so this change prevents that as well.