### PR TITLE
Enable middle-click for footer links

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -157,7 +157,7 @@
 	<div class="d-flex flex-row footer-options justify-content-center" [appColor]="themingService.bg.lighten(.05)" [isBackground]="true">
 		<span class="d-flex flex-row align-items-center footer-option" *ngFor="let btn of footerOptions; let index = index;">
 			<a *ngIf="!!btn.path" target="_blank" [href]="btn.path" class="text-muted">{{btn.name}}</a>
-			<a *ngIf="!!btn.click" (click)="btn.click()"> {{btn.name}} </a>
+			<a *ngIf="!!btn.route" [routerLink]="btn.route"> {{btn.name}} </a>
 
 			<div *ngIf="footerOptions.length > (index + 1)" class="mx-2 separator-ball d-block"></div>
 		</span>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -123,11 +123,11 @@ export class HomeComponent implements OnInit {
 		},
 		{
 			name: 'Privacy Policy',
-			click: () => this.router.navigate(['/legal', 'privacy'])
+			route: ['/legal', 'privacy']
 		},
 		{
 			name: 'Terms of Service',
-			click: () => this.router.navigate(['/legal', 'tos'])
+			route: ['/legal', 'tos']
 		}
 	] as HomeComponent.FooterOptions[];
 
@@ -281,6 +281,6 @@ export namespace HomeComponent {
 	export interface FooterOptions {
 		name: string;
 		path?: string;
-		click?: () => void;
+		route?: string[];
 	}
 }


### PR DESCRIPTION
Make home page footer links to Privacy Policy and TOS pages a `routerLink`.
This enables middle-clicking them, and allows copying the link, while still keeping the routing behavior (similar to `Learn more` button).